### PR TITLE
add equal to block definitions  

### DIFF
--- a/blocks_vertical/operators.js
+++ b/blocks_vertical/operators.js
@@ -171,7 +171,45 @@ Blockly.Blocks['operator_lt'] = {
     });
   }
 };
+Blockly.Blocks['operator_gtoreq'] = {
+  init: function() {
+    this.jsonInit({
+      "message0": "%1 >= %2",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "OPERAND1"
+        },
+        {
+          "type": "input_value",
+          "name": "OPERAND2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_boolean"]
+    });
+  }
+};
 
+Blockly.Blocks['operator_ltoreq'] = {
+  init: function() {
+    this.jsonInit({
+      "message0": "%1 <= %2",
+      "args0": [
+        {
+          "type": "input_value",
+          "name": "OPERAND1"
+        },
+        {
+          "type": "input_value",
+          "name": "OPERAND2"
+        }
+      ],
+      "category": Blockly.Categories.operators,
+      "extensions": ["colours_operators", "output_boolean"]
+    });
+  }
+};
 Blockly.Blocks['operator_equals'] = {
   /**
    * Block for equals comparator.


### PR DESCRIPTION
https://github.com/OmniBlocks/scratch-vm/pull/1 https://github.com/OmniBlocks/scratch-gui/issues/144

### Resolves
https://github.com/OmniBlocks/scratch-gui/issues/144
_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two comparison operator blocks: “≥” (greater than or equal) and “≤” (less than or equal).
  - These blocks output booleans and appear in the Operators category, matching the look and behavior of existing comparison blocks.
  - Enables inclusive comparisons for building conditions, such as thresholds and range checks, reducing the need for compound logic.
  - Improves clarity and efficiency when creating conditional statements in projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->