### PR TITLE
Fix missing import

### DIFF
--- a/core/field_customInput.js
+++ b/core/field_customInput.js
@@ -6,6 +6,10 @@
 
 goog.provide('Blockly.FieldCustom');
 
+goog.require('Blockly.Field');
+goog.require('Blockly.Events');
+goog.require('Blockly.FieldTextInput');
+
 const customInputs = new Map();
 
 /**


### PR DESCRIPTION
## The Problem: Missing Dependencies in field_customInput.js

`field_customInput.js` file is **missing the required `goog.require()` statements**

### What's Missing

Look at the difference:

**field_textinput.js (working):**
```javascript
goog.provide('Blockly.FieldTextInput');

goog.require('Blockly.BlockSvg.render');
goog.require('Blockly.Colours');
```

**field_customInput.js (broken):**
```javascript
goog.provide('Blockly.FieldCustom');

// no goog.require statements!
```

But then later in the file, it does:
```javascript
goog.inherits(Blockly.FieldCustom, Blockly.Field);
```

### Why This Breaks

The **Closure Compiler** (used by `build.py`) uses `goog.require()` to resolve dependencies and determine which files to include in the compilation. Without proper `goog.require()` statements:
1. The compiler can't resolve the dependency chain
2. The file gets skipped during compilation
3. The build "succeeds" but FieldCustom isn't in the output

### The Fix

just added these lines to the **top of field_customInput.js** (right after the `goog.provide` line):

```javascript
goog.provide('Blockly.FieldCustom');

goog.require('Blockly.Field');
goog.require('Blockly.Events');
goog.require('Blockly.FieldTextInput');
```
six seven